### PR TITLE
Reexport MultivariateStats

### DIFF
--- a/src/TimeseriesPrediction.jl
+++ b/src/TimeseriesPrediction.jl
@@ -5,7 +5,7 @@ module TimeseriesPrediction
 
 using Reexport
 @reexport using DynamicalSystemsBase
-
+@reexport using MultivariateStats
 using Statistics, LinearAlgebra
 
 include("localmodeling.jl")

--- a/src/pcaembedding.jl
+++ b/src/pcaembedding.jl
@@ -1,4 +1,3 @@
-using MultivariateStats: PCA, pcacov
 import IterTools: takenth, product
 export PCAEmbedding
 


### PR DESCRIPTION
Fix error when loading saved `PCAEmbedding`s. closes #50 

Lets see if tests pass.
Simply exporting `PCA` was not enough.
`@reexport MultivariateStats` however did the trick. 
Sadly `@reexport` does not seem to allow something like `@reexport import MultivariateStats: PCA`.



