### PR TITLE
Improve temporal prediction

### DIFF
--- a/src/temporalprediction.jl
+++ b/src/temporalprediction.jl
@@ -34,7 +34,8 @@ For available methods and interfaces see [`AbstractSpatialEmbedding`](@ref).
   * `ttype = KDTree` : Type/Constructor of tree structure. So far only tested with `KDTree`.
   * `method = AverageLocalModel(ω_safe)` : Subtype of [`AbstractLocalModel`](@ref).
   * `ntype = FixedMassNeighborhood(3)` : Subtype of [`AbstractNeighborhood`](@ref).
-  * `initial_ts = U` : Initial state for predictions plus past states for embedding. Defaults to the training set `U`.
+  * `initial_ts = U` : Initial states for prediction (same type as `U`). 
+    Must have at least as many states as the maximum delay time used. Defaults to the training set `U`.
   * `progress = true` : To print progress done.
 
 ## Description

--- a/src/temporalprediction.jl
+++ b/src/temporalprediction.jl
@@ -34,6 +34,7 @@ For available methods and interfaces see [`AbstractSpatialEmbedding`](@ref).
   * `ttype = KDTree` : Type/Constructor of tree structure. So far only tested with `KDTree`.
   * `method = AverageLocalModel(ω_safe)` : Subtype of [`AbstractLocalModel`](@ref).
   * `ntype = FixedMassNeighborhood(3)` : Subtype of [`AbstractNeighborhood`](@ref).
+  * `initial_ts = U` : Initial state for predictions plus past states for embedding. Defaults to the training set `U`.
   * `progress = true` : To print progress done.
 
 ## Description

--- a/test/st_coupledhenon_tests.jl
+++ b/test/st_coupledhenon_tests.jl
@@ -9,7 +9,7 @@ include("system_defs.jl")
     M = 100
     N_train = 2000
     p = 5
-    U, V = coupled_henon1D(M,N_train+p, rand(M), rand(M))
+    U, V = coupled_henon1D(M,N_train+p+100, rand(M), rand(M))
     #Reconstruct this #
     utrain = U[1:N_train]
     vtrain = V[1:N_train]
@@ -21,6 +21,17 @@ include("system_defs.jl")
         upred = temporalprediction(utrain,em, p)
 
         @test upred[1] == utrain[end]
+        @test sum(abs.(utest[2]-upred[2]))/M/p < 0.05
+        ε = [sum(abs.(utest[i]-upred[i])) for i=1:p+1]
+        @test sum(ε)/M / p < 0.15
+    end
+    @testset "1D Henon with offset start of pred" for D=3, B=2
+        em = cubic_shell_embedding(utrain,D,1,B,1,ConstantBoundary(10.))
+        ustart = U[N_train+100-4:N_train+100]
+        utest = U[N_train+100:N_train+p+100]
+        upred = temporalprediction(utrain,em, p; initial_ts=ustart)
+
+        @test upred[1] == ustart[end]
         @test sum(abs.(utest[2]-upred[2]))/M/p < 0.05
         ε = [sum(abs.(utest[i]-upred[i])) for i=1:p+1]
         @test sum(ε)/M / p < 0.15

--- a/test/st_coupledhenon_tests.jl
+++ b/test/st_coupledhenon_tests.jl
@@ -25,17 +25,19 @@ include("system_defs.jl")
         ε = [sum(abs.(utest[i]-upred[i])) for i=1:p+1]
         @test sum(ε)/M / p < 0.15
     end
-    @testset "1D Henon with offset start of pred" for D=3, B=2
+    @testset "1D Henon with offset start of pred" begin
+        D=3; B=2
         em = cubic_shell_embedding(utrain,D,1,B,1,ConstantBoundary(10.))
         ustart = U[N_train+100-4:N_train+100]
-        utest = U[N_train+100:N_train+p+100]
+        utest_off  = U[N_train+100:N_train+p+100]
         upred = temporalprediction(utrain,em, p; initial_ts=ustart)
 
         @test upred[1] == ustart[end]
-        @test sum(abs.(utest[2]-upred[2]))/M/p < 0.05
-        ε = [sum(abs.(utest[i]-upred[i])) for i=1:p+1]
+        @test sum(abs.(utest_off[2]-upred[2]))/M/p < 0.05
+        ε = [sum(abs.(utest_off[i]-upred[i])) for i=1:p+1]
         @test sum(ε)/M / p < 0.15
     end
+
     @testset "LLM D=$D, B=$B" for D=2:3, B=1:2
         method = LinearLocalModel(TimeseriesPrediction.ω_safe, 0.001, 1.)
         em = cubic_shell_embedding(utrain, D, 1, B,1, ConstantBoundary(10.))

--- a/test/st_pred_barkley.jl
+++ b/test/st_pred_barkley.jl
@@ -15,7 +15,7 @@ include("system_defs.jl")
     Ttrain = 400
     p = 20
     T = Ttrain + p
-    U, V = barkley(T; kwargs... )
+    U, V = barkley(T+100; kwargs... )
     Vtrain = V[1:Ttrain]
     Utrain = U[1:Ttrain]
 
@@ -30,6 +30,19 @@ include("system_defs.jl")
         em = PCAEmbedding(Vtrain, em)
         Vpred = temporalprediction(Vtrain,em,p)
         @test Vpred[1] == Vtrain[end]
+        err = [abs.(Vtest[i]-Vpred[i]) for i=1:p+1]
+        for i in 1:p
+            @test maximum(err[i]) < 0.2
+            @test minimum(err[i]) < 0.1
+        end
+    end
+    @testset "temp. pred. with offset start" for D=10, B=1
+        Vtest  = V[Ttrain+100:T+100]
+        Vstart = V[Ttrain+100-11:Ttrain+100]
+        em = cubic_shell_embedding(Vtrain,D,τ,B,k,BC)
+        em = PCAEmbedding(Vtrain, em)
+        Vpred = temporalprediction(Vtrain,em,p; initial_ts=Vstart)
+        @test Vpred[1] == Vstart[end]
         err = [abs.(Vtest[i]-Vpred[i]) for i=1:p+1]
         for i in 1:p
             @test maximum(err[i]) < 0.2


### PR DESCRIPTION
I added an optional keyword argument `initial_ts` for `temporalprediction`.

The end of `initial_ts` is used to reconstruct the first set of queries.
Condition:  `@assert length(initial_ts) > get_τmax(em)` (otherwise there are not enough timesteps for reconstruction )

`initial_ts` defaults to `s` , the training set. Therefore behaviour is unchanged if `initial_ts` is not set.


closes #53