### PR TITLE
add Test for Float32

### DIFF
--- a/test/st_pred_barkley.jl
+++ b/test/st_pred_barkley.jl
@@ -167,6 +167,7 @@ end
             @test maximum(err[i]) < 0.2
             @test minimum(err[i]) < 0.1
         end
+        @test Float32 == eltype(Vpred[1])
     end
     @testset "Cross Prediction" begin
         D = 10; B = 0
@@ -181,6 +182,7 @@ end
             @test minimum(err[i]) < 0.1
             @test mean(err[i]) < 0.1
         end
+        @test Float32 == eltype(Vpred[1])
     end
 end
 

--- a/test/st_pred_barkley.jl
+++ b/test/st_pred_barkley.jl
@@ -134,3 +134,84 @@ end
         end
     end
 end
+
+
+@testset "Half-Precision Tests" begin
+    kwargs = ( tskip = 200,
+               size = (50,50),
+               periodic= false,
+               a=0.75, b=0.02, ε=0.02, D=1, h=0.75, Δt=0.1)
+    Ttrain = 400
+    p = 20
+    T = Ttrain + p
+    U, V = barkley(T; kwargs... )
+    U = map(u -> Float32.(u), U)
+    V = map(v -> Float32.(v), V)
+    Vtrain = V[1:Ttrain]
+    Utrain = U[1:Ttrain]
+
+
+    τ = 1
+    k = 1
+    BC = ConstantBoundary{Float32}(20.)
+
+    @testset "Temporal Prediction" begin
+        D=10; B=1
+        Vtest  = V[Ttrain :  T]
+        em = cubic_shell_embedding(Vtrain,D,τ,B,k,BC)
+        em = PCAEmbedding(Vtrain, em)
+        Vpred = temporalprediction(Vtrain,em,p)
+        @test Vpred[1] == Vtrain[end]
+        err = [abs.(Vtest[i]-Vpred[i]) for i=1:p+1]
+        for i in 1:p
+            @test maximum(err[i]) < 0.2
+            @test minimum(err[i]) < 0.1
+        end
+    end
+    @testset "Cross Prediction" begin
+        D = 10; B = 0
+        p=10
+        Utest  = U[Ttrain-D*τ+1:T]
+        Vtest  = V[Ttrain+1:T]
+        em = cubic_shell_embedding(Utrain, D,τ,B,k,BC)
+        Vpred = crossprediction(Utrain,Vtrain,Utest, em)
+        err = [abs.(Vtest[i]-Vpred[i]) for i=1:p-1]
+        for i in 1:length(err)
+            @test maximum(err[i]) < 0.2
+            @test minimum(err[i]) < 0.1
+            @test mean(err[i]) < 0.1
+        end
+    end
+end
+
+# Complex Numbers are not compatible with KDTrees
+# @testset "Complex Number Test" begin
+#     kwargs = ( tskip = 200,
+#                size = (50,50),
+#                periodic= false,
+#                a=0.75, b=0.02, ε=0.02, D=1, h=0.75, Δt=0.1)
+#     Ttrain = 400
+#     p = 20
+#     T = Ttrain + p
+#     U, V = barkley(T; kwargs... )
+#     UV = map(U,V) do u,v
+#         u .+ 1im* v
+#     end
+#     UVtrain = UV[1:Ttrain]
+#     UVtest  = UV[Ttrain :  T]
+#
+#     @testset "Temporal Prediction" begin
+#         D=0; τ = 1; r = 1; c = 0
+#         BC = ConstantBoundary{ComplexF64}(20.)
+#         em = light_cone_embedding(UVtrain,D,τ,r,c,BC)
+#         UVpred = temporalprediction(UVtrain,em,p)
+#         @test Vpred[1] == Vtrain[end]
+#         err = [abs.(Vtest[i]-Vpred[i]) for i=1:p+1]
+#         for i in 1:p
+#             @test maximum(err[i]) < 0.2
+#             @test minimum(err[i]) < 0.1
+#         end
+#     end
+#
+#
+# end


### PR DESCRIPTION
Added a test for `Float32` in Barkley model.

Complex numbers do not work at the moment as 
`NearestNeighbors.jl` does not support them.

`ApproximateNearestNeighbors.jl` will fix that. It is completely number type and metric agnostic.
(coming soon)