### PR TITLE
Inhomogeneities

### DIFF
--- a/src/TimeseriesPrediction.jl
+++ b/src/TimeseriesPrediction.jl
@@ -13,6 +13,8 @@ include("localmodeling.jl")
 include("spatiotemporalembedding.jl")
 include("pcaembedding.jl")
 include("symmetric_embedding.jl")
+include("inhomogeneous_embedding.jl")
+
 include("reconstruct.jl")
 
 include("temporalprediction.jl")

--- a/src/inhomogeneous_embedding.jl
+++ b/src/inhomogeneous_embedding.jl
@@ -1,4 +1,22 @@
 export InhomogeneousEmbedding
+"""
+    InhomogeneousEmbedding(em::AbstractSpatialEmbedding, f)
+
+An `InhomogeneousEmbedding` can be used as a wrapper around an existing
+[`AbstractSpatialEmbedding`](@ref) to account for potential inhomogeneities
+in the system.
+
+It does so by reconstructing the local state as defined in `em`
+and appending the result of `f(α)` where `α` is the spatial `CartesianIndex`
+to the reconstructed vector.
+
+The inhomogeneity function `f` can be any function that takes as
+argument a `CartesianIndex{Φ}` and returns a `Tuple` or `Vector`
+of numbers to be added to the end of the local state vector.
+
+A convenience constructor for such a function is implemented in
+[`linear_weights`](@ref).
+"""
 struct InhomogeneousEmbedding{Φ, BC, X, Y, ASE <: AbstractSpatialEmbedding{Φ, BC, Y}, F} <: AbstractSpatialEmbedding{Φ,BC,X}
     em::ASE
     f::F
@@ -21,3 +39,27 @@ end
 get_num_pt(em::InhomogeneousEmbedding) = get_num_pt(em.em)
 get_τmax(em::InhomogeneousEmbedding) = get_τmax(em.em)
 get_usable_idxs(em::InhomogeneousEmbedding) = get_usable_idxs(em.em)
+
+"""
+    linear_weights(fsize::NTuple{Φ,Int}, φs = 1:Φ, scalefactor = fill(one(T),length(φs))) where {Φ}
+
+Convenience constructor for a linear inhomogeneity function.
+Returns a function `f(α::CartesianIndex{Φ})` that computes a spatial weighting
+for `α`.
+
+ `fsize` the size of the domain that
+is needed for normalizing the values to +-1.
+`φs` and `scalefactor` are optional arguments that allow to
+restrict the weighting to some subset of the spatial dimensions
+and to rescale the values with scalefactor.
+"""
+function linear_weights(fsize::NTuple{Φ,Int}, φs = 1:Φ, weights = fill(1,length(φs))) where {Φ}
+    function f(α::CartesianIndex)
+        map(φs,weights) do φ, w
+            i = α.I[φ]
+            s = fsize[φ]
+            w*(2(i-1)/(s-1) - 1)
+        end
+    end
+    return f
+end

--- a/src/inhomogeneous_embedding.jl
+++ b/src/inhomogeneous_embedding.jl
@@ -1,0 +1,23 @@
+export InhomogeneousEmbedding
+struct InhomogeneousEmbedding{Φ, BC, X, Y, ASE <: AbstractSpatialEmbedding{Φ, BC, Y}, F} <: AbstractSpatialEmbedding{Φ,BC,X}
+    em::ASE
+    f::F
+end
+
+function InhomogeneousEmbedding(em::AbstractSpatialEmbedding{Φ,BC,Y}, f) where {Φ,BC,Y}
+    #Determine output dimension of f
+    l = length(f(CartesianIndex(zeros(Int,Φ)...)))
+    X = Y + l
+    return InhomogeneousEmbedding{Φ,BC,X,Y, typeof(em), typeof(f)}(em,f)
+end
+
+function (r::InhomogeneousEmbedding{Φ,BC,X,Y})(rvec, s, t ,α) where {Φ,BC,X,Y}
+    #give the internal embedding a view of rvec
+    r.em(view(rvec,1:Y), s, t, α)
+    rvec[Y+1:X] .= r.f(α)
+    return nothing
+end
+
+get_num_pt(em::InhomogeneousEmbedding) = get_num_pt(em.em)
+get_τmax(em::InhomogeneousEmbedding) = get_τmax(em.em)
+get_usable_idxs(em::InhomogeneousEmbedding) = get_usable_idxs(em.em)

--- a/src/spatiotemporalembedding.jl
+++ b/src/spatiotemporalembedding.jl
@@ -177,7 +177,7 @@ function Base.show(io::IO, em::SpatioTemporalEmbedding{Φ,BC, X}) where {Φ,BC,X
     if BC == PeriodicBoundary
         println(io, " and PeriodicBoundary condition.")
     else
-        println(io, " and ConstantBoundary condition with c = $(em.boundary.c).")
+        println(io, " and ConstantBoundary condition with b = $(em.boundary.b).")
     end
     println(io, "The included neighboring points are (forward embedding):")
     for (τ,β) in zip(em.τ,em.β)

--- a/src/symmetric_embedding.jl
+++ b/src/symmetric_embedding.jl
@@ -90,7 +90,7 @@ function Base.show(io::IO, em::SymmetricEmbedding{Φ,BC, X}) where {Φ,BC,X}
     if BC == PeriodicBoundary
         println(io, " and PeriodicBoundary condition.")
     else
-        println(io, " and ConstantBoundary condition with c = $(em.boundary.c).")
+        println(io, " and ConstantBoundary condition with b = $(em.boundary.b).")
     end
     println(io, "The included neighboring points are (forward embedding):")
     for (τ,β) in zip(em.τ,em.β_groups)

--- a/test/inhomogeneity_tests.jl
+++ b/test/inhomogeneity_tests.jl
@@ -1,0 +1,31 @@
+2using Test
+using TimeseriesPrediction
+
+@testset "InhomogeneousEmbedding" begin
+    #Test reconstruction
+    γ = 0; τ = 1; r = 2; c = 0; bc = ConstantBoundary(10.);
+    dummy_data = [rand(10,10) for _ in 1:10]
+    em = light_cone_embedding(dummy_data, γ, τ, r, c, bc)
+
+    ff = TimeseriesPrediction.linear_weights(size(dummy_data[1]))
+    iem = InhomogeneousEmbedding(em, ff)
+
+    R1 = reconstruct(dummy_data, em)
+    R2 = reconstruct(dummy_data, iem)
+    for (r1,r2) in zip(R1,R2)
+        @test r1 == r2[1:end-2]
+    end
+
+    #Test linear weights function
+
+    ff = TimeseriesPrediction.linear_weights(size(dummy_data[1]))
+    iem = InhomogeneousEmbedding(em, ff)
+    @test outdim(iem) == outdim(em)+2
+    @test [-1, 1] == ff(CartesianIndex(1,10))
+    ff = TimeseriesPrediction.linear_weights(size(dummy_data[1]),2)
+    iem = InhomogeneousEmbedding(em, ff)
+    @test outdim(iem) == outdim(em)+1
+    @test [1] == ff(CartesianIndex(1,10))
+    @test [-1] == ff(CartesianIndex(1,1))
+
+end

--- a/test/inhomogeneity_tests.jl
+++ b/test/inhomogeneity_tests.jl
@@ -1,4 +1,4 @@
-2using Test
+using Test
 using TimeseriesPrediction
 
 @testset "InhomogeneousEmbedding" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,8 @@ include("localmodeling_tests.jl")
 include("st_pred_barkley.jl")
 include("st_coupledhenon_tests.jl")
 include("reconstruction_tests.jl")
+include("inhomogeneity_tests.jl")
+include("symmetry_tests.jl")
 ti = time() - ti
 println("\nTest took total time of:")
 println(round(ti, digits=3), " seconds or ", round(ti/60, digits=3), " minutes")


### PR DESCRIPTION
This PR implements a new embedding type `InhomogeneousEmbedding`
allows handling inhomogeneities with a spatial weighting function.

It does so with a function `f(α::CartesianIndex) → [weights..]`
that returns a fixed number of weights that are then appended to the end of each reconstructed vector.
