### PR TITLE
New symmetry API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,11 @@
 name = "TimeseriesPrediction"
 uuid = "f218859d-9706-56aa-9ebf-1fa4ed7b8020"
 repo = "https://github.com/JuliaDynamics/TimeseriesPrediction.jl.git"
+version = "0.7.0"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
@@ -15,10 +17,10 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [extras]
+DynamicalSystemsBase = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-DynamicalSystemsBase = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 
 [targets]
 test = ["MultivariateStats", "DynamicalSystemsBase"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1
-  - julia_version: nightly
+  # - julia_version: nightly
 
 platform:
   - x86 # 32-bit
@@ -40,4 +40,3 @@ test_script:
 # on_success:
 #   - echo "%JL_CODECOV_SCRIPT%"
 #   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"
-

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,3 +37,4 @@ pages:
 - Local Modeling & Timeseries Prediction: localmodels.md
 - Spatio-Temporal Prediction: spatiotemporal.md
 - Spatio-Temporal Examples: stexamples.md
+- Exploiting Spatial Symmetries: symmetry.md

--- a/docs/src/symmetry.md
+++ b/docs/src/symmetry.md
@@ -1,0 +1,23 @@
+# Exploiting Spatial Symmetries
+
+Some systems have symmetries that apply to their spatial dimensions. For example, the Barkley model that we use an example has equations:
+```math
+u_t = \frac{1}{\epsilon}u(1-u)(u-\frac{v+b}{a}) + \nabla^2 u \\
+v_t = u^3 - v
+```
+The only spatial coupling component is the Laplacian operator, ``\nabla^2``. This means that the equations of of the Barkley model have rotational symmetry with respect to space.
+
+In principle one should be able to take advantage of these symmetries to reduce the embedded space dimension.
+
+## Symmetries
+We encode symmetries with the following types:
+```@docs
+Symmetry
+Reflection
+Rotation
+```
+## Symmetric Embedding
+You can use the symmetries in the following embedding:
+```@docs
+SymmetricEmbedding
+```

--- a/docs/src/symmetry.md
+++ b/docs/src/symmetry.md
@@ -1,11 +1,11 @@
 # Exploiting Spatial Symmetries
 
-Some systems have symmetries that apply to their spatial dimensions. For example, the Barkley model that we use an example has equations:
+Some systems have symmetries that apply to their spatial dimensions. For example, the cubic Barkley model has equations:
 ```math
 u_t = \frac{1}{\epsilon}u(1-u)(u-\frac{v+b}{a}) + \nabla^2 u \\
 v_t = u^3 - v
 ```
-The only spatial coupling component is the Laplacian operator, ``\nabla^2``. This means that the equations of of the Barkley model have rotational symmetry with respect to space.
+The only spatial coupling component is the Laplacian operator, ``\nabla^2``. This means that the equations of the Barkley model have rotational symmetry with respect to space.
 
 In principle one should be able to take advantage of these symmetries to reduce the embedded space dimension.
 

--- a/src/symmetric_embedding.jl
+++ b/src/symmetric_embedding.jl
@@ -1,9 +1,24 @@
 using InteractiveUtils
 export SymmetricEmbedding
-export Reflection, Rotation
+export Reflection, Rotation, Symmetry
 
+"""
+	Symmetry
+Supertype of all symmetries used in [`SymmetricEmbedding`](@ref).
+All symmetries are initialized like `Symmetry(n1, n2, ...)` with
+`ni` being the indices of the spatial dimensions that have the said symmetry.
+
+E.g. `Reflection(1,2)` means that spatial dimensions 1 and 2 have a reflection
+symmetry, while `Rotation(1,3)` means that spatial dimensions 1 and 3 have a
+(joint) rotation symmetry.
+"""
 abstract type Symmetry end
 
+"""
+	Rotation <: Symmetry
+Rotation symmetry (index sets at equal distance from the center point are
+equivalent), which is a joint symmetry between all input dimensions.
+"""
 struct Rotation <: Symmetry
 	d::Vector{Int}
 	function Rotation(args::Vector{Int})
@@ -12,6 +27,10 @@ struct Rotation <: Symmetry
 	end
 end
 
+"""
+	Reflection <: Symmetry
+Reflection symmetry: x and -x are equavalent (for the given dimension).
+"""
 struct Reflection <: Symmetry
 	d::Vector{Int}
 end
@@ -48,22 +67,20 @@ end
 
 A `SymmetricEmbedding` is intended as a means of dimension reduction
 for a [`SpatioTemporalEmbedding`](@ref) by exploiting spatial symmetries in
-the system, listed as a `Tuple` of `<:Symmetry`.
+the system, listed as a `Tuple` of `<:Symmetry` (see [`Symmetry`](@ref)) for
+all possible symmetries.
 
 All points at a time step equivalent to each other according to the symmetries
-passed in `sym` will be **averaged** to a single entry! See the documentation
-around [`Symmetry`](@ref) for all the symmetry types as well as examples.
+passed in `sym` will be **averaged** to a single entry! For example,
+the symmetry `Reflection(2)` means that the embedding won't have two entries
+`u[i, j+1], u[i, j-1]` but instead a single entry
+`(u[i, j+1] + u[i, j-1])/2`, with `i,j` being indices *relative to the
+central point of the embedding*. (the same process is
+done for any index offset `j+2, j+3`, etc., depending on how large the
+spatial radius `r` is)
 
-A few examples for clarification:
- * 2D space with mirror symmetry along first dimension : `sym = [ [1] ]` → maps points  to `(s[t][+n, m] + s[t][-n, m])/2`
- * 2D space with mirror symmetry along each dimension : `sym = [ [1], [2] ]` → averages over points with `(+- n, +- m)`
- * 2D space with point symmetry in both dimensions : `sym = [ [1,2] ]` → groups points with equal distance to the origin such as `(1,2), (-1,2), (2,1),...`
- * 3D space with point symmetry in dim 1 & 3 and mirror in 2: `sym = [ [1,3], [2]]` → groups points with equal distance to the origin along dimension 1 & 3 and +-2
-
-To further explain the last example: The following points form one such group
-`(+-2,1,0), (0,1,+-2), (-2,-1,0), (0,-1,-2)`
-
-The resulting structure can be used for reconstructing datasets in
+The resulting structure from `SymmetricEmbedding`
+can be used for reconstructing datasets in
 the same way as a [`SpatioTemporalEmbedding`](@ref).
 """
 struct SymmetricEmbedding{Φ,BC,X} <: AbstractSpatialEmbedding{Φ,BC,X}

--- a/src/symmetric_embedding.jl
+++ b/src/symmetric_embedding.jl
@@ -2,21 +2,21 @@ export SymmetricEmbedding
 
 abstract type Symmetry end
 
-struct Rotation{N} <: Symmetry
-	d::NTuple{N, Int}
-	function Rotation(args...)
+struct Rotation <: Symmetry
+	d::Vector{Int}
+	function Rotation(args::Vector{Int})
 		@assert length(args) > 1 "Rotation symmetry needs at least 2 dimensions"
 		@assert length(args) == 2 "Only rotation symmetry in 2D is currently implemented"
-		new{length(args)}((args...,))
+		new(args)
 	end
 end
 
-struct Reflection{N} <: Symmetry
-	d::NTuple{N, Int}
+struct Reflection <: Symmetry
+	d::Vector{Int}
 end
 
-for sym in [:Reflection]
-	@eval $(sym)(args...) = $(sym){length(args)}((args...,))
+for sym in Symbol.(subtypes(Symmetry))
+	@eval $(sym)(x::Int, args...) = $(sym)([x, args...])
 end
 
 # internal translation to the nested vectors of integers
@@ -24,13 +24,12 @@ end
 # (if we ever encounter a different symmetry we want to use)
 function _nestedvec(syms::Tuple)
 	# This part of the code ensures no duplicate symmetries
-	N = sum(length(s.d) for s in syms)
-	allidx = vcat(collect([s.d...] for s in syms)...)
+	allidx = vcat(s.d for s in syms)
 	@assert unique(allidx) == allidx
 	# Now convert to nestedvec
 	v = Vector{Vector{Int}}()
 	for s in syms
-		push!(v, [s.d...])
+		push!(v, s.d)
 	end
 	return v
 end

--- a/src/symmetric_embedding.jl
+++ b/src/symmetric_embedding.jl
@@ -1,4 +1,6 @@
+using InteractiveUtils
 export SymmetricEmbedding
+export Reflection, Rotation
 
 abstract type Symmetry end
 
@@ -6,7 +8,6 @@ struct Rotation <: Symmetry
 	d::Vector{Int}
 	function Rotation(args::Vector{Int})
 		@assert length(args) > 1 "Rotation symmetry needs at least 2 dimensions"
-		@assert length(args) == 2 "Only rotation symmetry in 2D is currently implemented"
 		new(args)
 	end
 end
@@ -17,6 +18,14 @@ end
 
 for sym in Symbol.(subtypes(Symmetry))
 	@eval $(sym)(x::Int, args...) = $(sym)([x, args...])
+end
+
+# Overload `NTuple{N,T} where {N,T<:A}` for `show`
+_smallstr(::Rotation) = "rot"
+_smallstr(::Reflection) = "refl"
+function Base.show(io::IO, sym::Symmetry)
+	s = _smallstr(sym)*string(sym.d)
+	print(io, s)
 end
 
 # internal translation to the nested vectors of integers
@@ -67,7 +76,7 @@ end
 
 function SymmetricEmbedding(ste::SpatioTemporalEmbedding, sym::Tuple)
 	nv = _nestedvec(sym)
-	_SymmetricEmbedding(stem, nv)
+	_SymmetricEmbedding(ste, nv)
 end
 
 # Internal function, uses the nested vectors until we change it /

--- a/src/symmetric_embedding.jl
+++ b/src/symmetric_embedding.jl
@@ -7,6 +7,9 @@ export Reflection, Rotation, Symmetry
 Supertype of all symmetries used in [`SymmetricEmbedding`](@ref).
 All symmetries are initialized like `Symmetry(n1, n2, ...)` with
 `ni` being the indices of the spatial dimensions that have the said symmetry.
+
+Notice that the symmetries are defined with respect to the center point
+of the embedding.
 """
 abstract type Symmetry end
 

--- a/src/symmetric_embedding.jl
+++ b/src/symmetric_embedding.jl
@@ -7,17 +7,19 @@ export Reflection, Rotation, Symmetry
 Supertype of all symmetries used in [`SymmetricEmbedding`](@ref).
 All symmetries are initialized like `Symmetry(n1, n2, ...)` with
 `ni` being the indices of the spatial dimensions that have the said symmetry.
-
-E.g. `Reflection(1,2)` means that spatial dimensions 1 and 2 have a reflection
-symmetry, while `Rotation(1,3)` means that spatial dimensions 1 and 3 have a
-(joint) rotation symmetry.
 """
 abstract type Symmetry end
 
 """
 	Rotation <: Symmetry
-Rotation symmetry (index sets at equal distance from the center point are
-equivalent), which is a joint symmetry between all input dimensions.
+Index sets at equal distance from the center point are equivalent,
+for the given input dimensions. E.g. for `Rotation(1,3)` and given center
+point `u[i,j,k,...]` all indices `m, n` that satisfy
+```
+|i-m|^2 + |k-n|^2 = r^2
+```
+for a given ``r``, are equivalent.
+The same process generalizes to any number of input dimensions.
 """
 struct Rotation <: Symmetry
 	d::Vector{Int}
@@ -29,7 +31,7 @@ end
 
 """
 	Reflection <: Symmetry
-Reflection symmetry: x and -x are equavalent (for the given dimension).
+Reflection symmetry: x and -x are equivalent (for all given dimensions).
 """
 struct Reflection <: Symmetry
 	d::Vector{Int}

--- a/test/symmetry_tests.jl
+++ b/test/symmetry_tests.jl
@@ -1,6 +1,10 @@
-using Test
 using TimeseriesPrediction
+using Test
 using Statistics, LinearAlgebra
+
+# Test:
+# For example, to have rotational 2D in x-z and reflection in y:
+syms = (Rotation(1,3), Reflection(2))
 
 @testset "SymmetricEmbedding" begin
     @testset "Ordering in β_groups" begin
@@ -8,7 +12,10 @@ using Statistics, LinearAlgebra
         dummy_data = [rand(10,10,10) for _ in 1:10]
         em = light_cone_embedding(dummy_data, γ, τ, r, c, bc)
 
-        symmetries = [ [[1]], [[2]], [[1,3]], [[1,2,3]], [[3,1], [2]] ]
+        symmetries = [(Reflection(1),), (Reflection(2),), (Rotation(1,3),),
+        (Rotation(1,2,3),), (Rotation(1,3), Reflection(2))]
+
+        # symmetries = [ [[1]], [[2]], [[1,3]], [[1,2,3]], [[3,1], [2]] ]
         @testset "Symmetry $sym" for sym in symmetries
             sem = SymmetricEmbedding(em, sym)
             # Check that first entry is always origin
@@ -32,7 +39,10 @@ using Statistics, LinearAlgebra
         dummy_data = [rand(10,10,10,10) for _ in 1:10]
         em = light_cone_embedding(dummy_data, γ, τ, r, c, bc)
 
-        symmetries = [ [[1,4]], [[1,2,3,4]], [[3,1], [2]] ]
+        symmetries = [(Rotation(1,4),), (Rotation(1,2,3,4),),
+                    (Rotation(1,3), Reflection(2))]
+
+        # symmetries = [ [[1,4]], [[1,2,3,4]], [[3,1], [2]] ]
         @testset "Symmetry $sym" for sym in symmetries
             sem = SymmetricEmbedding(em, sym)
 
@@ -53,7 +63,9 @@ using Statistics, LinearAlgebra
         dummy_data = [rand(10,10,10) for _ in 1:10]
         em = light_cone_embedding(dummy_data, γ, τ, r, c, bc)
 
-        symmetries = [ [[1]], [[2]], [[1,3]], [[1,2,3]], [[3,1], [2]] ]
+        symmetries = [(Reflection(1),), (Reflection(2),), (Rotation(1,3),),
+                      (Rotation(1,2,3),), (Rotation(1,3), Reflection(2))]
+        # symmetries = [ [[1]], [[2]], [[1,3]], [[1,2,3]], [[3,1], [2]] ]
         @testset "Symmetry $sym" for sym in symmetries
             sem = SymmetricEmbedding(em, sym)
 
@@ -68,7 +80,10 @@ using Statistics, LinearAlgebra
         dummy_data = [rand(10,10) for _ in 1:10]
         em = light_cone_embedding(dummy_data, γ, τ, r, c, bc)
 
-        symmetries = [ [[0]], [[3]], [[1,3]], [[2,0]], [[2,1], [2]] ]
+        symmetries = [(Reflection(0),), (Reflection(3),), (Rotation(1,3),),
+                      (Rotation(2,0),), (Rotation(1,2), Reflection(2))]
+        # symmetries = [ [[0]], [[3]], [[1,3]], [[2,0]], [[2,1], [2]] ]
+
         @testset "Symmetry $sym" for sym in symmetries
             @test_throws ArgumentError SymmetricEmbedding(em, sym)
         end
@@ -80,7 +95,8 @@ using Statistics, LinearAlgebra
             γ = 2; τ = 5; r = 1; c = 0;
             data = [rand(25,25) for _ in 1:50]
             em = light_cone_embedding(data, γ, τ, r, c, bc)
-            sem = SymmetricEmbedding(em, [[1,2]])
+            sem = SymmetricEmbedding(em, (Rotation(1,2),))
+            # sem = SymmetricEmbedding(em, [[1,2]])
 
             #Check wether this works in principle
             r1 = reconstruct(data, sem);


### PR DESCRIPTION
This PR installs a new symmetry API.

* Each symmetry is encoded in a type `<: Symmetry`. Each type has a field `d` which is a vector of which spatial dimensions the symmetry targets.
* The current status quo is that the new API is internally translated to the old nested vectors.
* In the future we should change this to get rid of the nested vectors and translated into `β_groups` directly, if we want to extend it. But this is very low priority I would guess.
* I will also add some *preliminary* symmetry documentation that I think Jonas should finalize with a nice example.
* The symmetry api is of course verbose (so that it is transparent) but I've defined a quite concise `show` overloading so that the symmetries still look decently small when printed in a dataframe. E.g. we have: `(rot[1, 3], refl[2])`

