### PR TITLE
Always benchmark when you code

### DIFF
--- a/src/pcaembedding.jl
+++ b/src/pcaembedding.jl
@@ -54,14 +54,10 @@ function PCAEmbedding(
 	for (α, t) ∈ subset
 		stem(recv, s,t,α)
 		recv  .-= meanv
-		#covmat .+= recv' .* recv / L
-		# Compute only  upper triangular half
-		@inbounds for j=1:Y, i=1:j
+		@inbounds for j=1:Y, i=1:Y
 			covmat[i,j] += recv[i]*recv[j] / L
 		end
 	end
-	#Copy upper half to bottom
-	LowerTriangular(covmat) .= UpperTriangular(covmat)'
 	drmodel = compute_pca(covmat,pratio, maxoutdim)
 	X = size(drmodel.proj,2)
 	tmp = zeros(Y)


### PR DESCRIPTION
```
using BenchmarkTools
using LinearAlgebra

function mykron1!(covmat, v)
    L = length(v)
    @inbounds for j=1:L, i=1:j
        covmat[i,j] += v[i]*v[j] #this operation is done in high precision
    end
    LowerTriangular(covmat) .= UpperTriangular(covmat)'
    return nothing
end

function mykron2!(covmat, v)
    L = length(v)
    @inbounds for j=1:L, i=1:L
        covmat[i,j] += v[i]*v[j] #this operation is done in high precision
    end
    return nothing
end

function normalkron!(covmat, v)
    tmp = kron(v,v')
    covmat .+= tmp
    return nothing
end

function mulkron!(covmat, v, covmat_tmp)
    mul!(covmat_tmp, v, v')
    covmat .+= covmat_tmp
    return nothing
end

N = 2000;
v = rand(N);
covmat =  zeros(N,N);
covmat_tmp =  zeros(N,N);

@btime mykron1!($covmat, $v)
@btime mykron2!($covmat, $v)
@btime normalkron!($covmat, $v)
@btime mulkron!($covmat, $v, $covmat_tmp)
```
gives
```
21.524 ms (3 allocations: 48 bytes)
  2.903 ms (0 allocations: 0 bytes)
  17.896 ms (5 allocations: 30.52 MiB)
  28.244 ms (0 allocations: 0 bytes)
```
I therefore changed the hotloop of PCAEmbedding to the much faster version