### PR TITLE
Use `pkgdir`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,7 +10,7 @@ function replace_includes(str)
     included = ["1Dfield_temporalprediction.jl",
     "2Dfield_crossprediction.jl", "2Dfield_temporalprediction.jl"]
 
-    path = dirname(dirname(pathof(TimeseriesPrediction)))*"/examples/"
+    path = pkgdir(TimeseriesPrediction)*"/examples/"
 
     for ex in included
         content = read(path*ex, String)

--- a/docs/src/stexamples.jl
+++ b/docs/src/stexamples.jl
@@ -5,7 +5,7 @@
 # This is how you can (programmatically) find this folder:
 # ```julia
 # using TimeseriesPrediction
-# exdir = dirname(dirname(pathof(TimeseriesPrediction)))*"/examples"
+# exdir = pkgdir(TimeseriesPrediction)*"/examples"
 # ```
 
 # ## Temporal Prediction: Kuramoto-Sivashinsky

--- a/examples/1Dfield_temporalprediction.jl
+++ b/examples/1Dfield_temporalprediction.jl
@@ -15,7 +15,7 @@
 using PyPlot
 using TimeseriesPrediction
 
-testdir = dirname(dirname(pathof(TimeseriesPrediction)))*"/test"
+testdir = pkgdir(TimeseriesPrediction)*"/test"
 @assert isdir(testdir)
 include(testdir*"/ks_solver.jl")
 

--- a/examples/2Dfield_crossprediction.jl
+++ b/examples/2Dfield_crossprediction.jl
@@ -12,7 +12,7 @@
 using PyPlot
 using TimeseriesPrediction
 
-testdir = dirname(dirname(pathof(TimeseriesPrediction)))*"/test"
+testdir = pkgdir(TimeseriesPrediction)*"/test"
 @assert isdir(testdir)
 include(testdir*"/system_defs.jl")
 

--- a/examples/2Dfield_temporalprediction.jl
+++ b/examples/2Dfield_temporalprediction.jl
@@ -12,7 +12,7 @@
 using PyPlot
 using TimeseriesPrediction
 
-testdir = dirname(dirname(pathof(TimeseriesPrediction)))*"/test"
+testdir = pkgdir(TimeseriesPrediction)*"/test"
 @assert isdir(testdir)
 include(testdir*"/system_defs.jl")
 

--- a/examples/CoupledMaps_temporalprediction.jl
+++ b/examples/CoupledMaps_temporalprediction.jl
@@ -16,7 +16,7 @@
 using PyPlot
 using TimeseriesPrediction
 
-testdir = dirname(dirname(pathof(TimeseriesPrediction)))*"/test"
+testdir = pkgdir(TimeseriesPrediction)*"/test"
 @assert isdir(testdir)
 include(testdir*"/system_defs.jl")
 


### PR DESCRIPTION
Since [Julia 1.4](https://github.com/JuliaLang/julia/blob/v1.4.2/NEWS.md), there is the very convenient `pkgdir` which many people overlook. Via code searches, I noticed that this repository uses a few `dirname(dirname(pathof(TimeseriesPrediction)))` which is the same as `pkgdir(TimeseriesPrediction)`, so this PR proposes to replace that.